### PR TITLE
Benchmark layerwise performance with storing only

### DIFF
--- a/bench-spec.yaml
+++ b/bench-spec.yaml
@@ -8,22 +8,22 @@ Infrastructure:
 Serving:
   Baseline: Direct-ProductionStack
   Direct-ProductionStack:
-    kubernetesConfigSelection: llama8B_lmcache_basic.yaml
+    kubernetesConfigSelection: layerwise/w.yaml
     hf_token: <YOUR_HF_TOKEN> # do NOT modify if you are using LMCacheGKE (keep as <YOUR_HF_TOKEN>). This is only needed for LocalMinikube
     modelURL: meta-llama/Llama-3.1-8B-Instruct
 
-  # Baseline: Helm-ProductionStack
-  # Helm-ProductionStack:
-  #   vLLM-Version: 0 # vllm v0 or v1
-  #   enablePrefixCaching: false # vllm v1 specific only (no prefix caching in v0)
-  #   useLMCache: false # true or false
-  #   modelURL: meta-llama/Llama-3.1-8B-Instruct
-  #   replicaCount: 1 # PLEASE make sure that replicaCount x numGPUs <= numClusterGPUs
-  #   numGPUs: 1 # PLEASE make sure that replicaCount x numGPUs <= numClusterGPUs
-  #   numCPUs: 4 # PLEASE look at the vCPU limits in the comment above (try to keep 12 or below)
-  #   tensorParallelSize: 1 # please make sure tensorParallelSize <= numGPUs (this is the number of GPUs per replica)
-  #   hf_token: <YOUR_HF_TOKEN> # do NOT modify if you are using LMCacheGKE (keep as <YOUR_HF_TOKEN>). This is only needed for LocalMinikube
-  #   maxModelLen: 16384
+#   Baseline: Helm-ProductionStack
+#   Helm-ProductionStack:
+#     vLLM-Version: 0 # vllm v0 or v1
+#     enablePrefixCaching: false # vllm v1 specific only (no prefix caching in v0)
+#     useLMCache: false # true or false
+#     modelURL: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+#     replicaCount: 1 # PLEASE make sure that replicaCount x numGPUs <= numClusterGPUs
+#     numGPUs: 1 # PLEASE make sure that replicaCount x numGPUs <= numClusterGPUs
+#     numCPUs: 4 # PLEASE look at the vCPU limits in the comment above (try to keep 12 or below)
+#     tensorParallelSize: 1 # please make sure tensorParallelSize <= numGPUs (this is the number of GPUs per replica)
+#     hf_token: <YOUR_HF_TOKEN> # do NOT modify if you are using LMCacheGKE (keep as <YOUR_HF_TOKEN>). This is only needed for LocalMinikube
+#     maxModelLen: 16384
 
 Workload:
 
@@ -55,13 +55,13 @@ Workload:
   #     USE_SHAREGPT: true
 
     # short input short output:
-    - NUM_USERS_WARMUP: 400
-      NUM_USERS: 320
-      NUM_ROUNDS: 20
+    - NUM_USERS_WARMUP: 0
+      NUM_USERS: 10
+      NUM_ROUNDS: 2
       SYSTEM_PROMPT: 0
-      CHAT_HISTORY: 256
+      CHAT_HISTORY: 8000
       ANSWER_LEN: 20
-      QPS: [15]
+      QPS: [0.5, 1, 1.5, 1.6, 1.7, 2]
       USE_SHAREGPT: false
 
   # Mooncake:


### PR DESCRIPTION
# How to request a run benchmarks on the LMCache GPU runner:

1. Reason/Description:

Benchmark layerwise performance with storing only.

2. Modify `bench-spec.yaml`